### PR TITLE
feat: add reusable Card component for standardized UI

### DIFF
--- a/src/app/components/Card.tsx
+++ b/src/app/components/Card.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import React from 'react';
+
+interface CardProps {
+  href?: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * A generic Card component that provides consistent styling for items like voting systems cards.
+ * It renders as an anchor tag if an `href` is supplied, otherwise as a div.
+ */
+export function Card({ href, className = '', children }: CardProps) {
+  const baseClasses = [
+    'group relative block max-w-full rounded-xl border shadow-sm transition',
+    'bg-[var(--card)] border-[var(--border)] hover:bg-[var(--card-hover)]',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+  if (href) {
+    return (
+      <a href={href} className={baseClasses}>
+        {children}
+      </a>
+    );
+  }
+  return <div className={baseClasses}>{children}</div>;
+}


### PR DESCRIPTION
This pull request introduces a reusable Card component in `src/app/components`. The new Card component provides standardized styling for card-like UI elements, reducing redundant Tailwind classes across the project. It accepts optional `href` and `className` props and renders either an anchor tag or div depending on presence of `href`. The component uses CSS variables for card background, border, and hover states to ensure consistent theming.

This sets up the foundation for further refactoring of existing components such as `VotingSystemCard` to use this Card primitive, which will simplify markup and improve maintainability.